### PR TITLE
Feat write prompt

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import Navbar from "./components/Navbar";
 import "bootstrap/dist/css/bootstrap.min.css";
 import Prompt from "./pages/Prompt";
 import WriteStory from "./pages/WriteStory";
+import WritePrompt from "./pages/WritePrompt";
 
 function App() {
   return (
@@ -16,6 +17,7 @@ function App() {
         <Route exact path="/" component={Home} />
         <Route path="/profile" component={Profile} />
         <Route path="/login" component={Login} />
+        <Route exact path="/prompt/new" component={WritePrompt} />
         <Route path="/prompt/:id" component={Prompt} />
         <Route path="/write/:id" component={WriteStory} />
       </Switch>

--- a/src/pages/WritePrompt.js
+++ b/src/pages/WritePrompt.js
@@ -1,0 +1,48 @@
+import React, { useState } from "react";
+import { Container, Form, Button } from "react-bootstrap";
+
+export default function WritePrompt() {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+
+  function submitForm(event) {
+    event.preventDefault();
+    const userId = 2;
+
+    console.log("prompt:", { userId, description, name });
+  }
+
+  return (
+    <Container>
+      <h1>Write a prompt</h1>
+      <Form>
+        <Form.Group controlId="formBasicName">
+          <Form.Label>Title of your Prompt:</Form.Label>
+          <Form.Control
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            type="text"
+            placeholder="What is your prompt called?"
+          />
+        </Form.Group>
+        <Form.Group controlId="formBasicTextArea">
+          <Form.Label>Write your Prompt:</Form.Label>
+
+          <Form.Control
+            as="textarea"
+            rows="10"
+            value={description}
+            onChange={(event) => setDescription(event.target.value)}
+            placeholder="In a World..."
+            required
+          />
+        </Form.Group>
+        <Form.Group className="mt-5">
+          <Button variant="primary" type="submit" onClick={submitForm}>
+            Submit Prompt
+          </Button>
+        </Form.Group>
+      </Form>
+    </Container>
+  );
+}

--- a/src/pages/WritePrompt.js
+++ b/src/pages/WritePrompt.js
@@ -1,7 +1,10 @@
 import React, { useState } from "react";
 import { Container, Form, Button } from "react-bootstrap";
+import { useDispatch } from "react-redux";
+import { postPrompt } from "../store/prompts/actions";
 
 export default function WritePrompt() {
+  const dispatch = useDispatch();
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
 
@@ -9,7 +12,7 @@ export default function WritePrompt() {
     event.preventDefault();
     const userId = 2;
 
-    console.log("prompt:", { userId, description, name });
+    dispatch(postPrompt(userId, description, name));
   }
 
   return (

--- a/src/store/prompts/actions.js
+++ b/src/store/prompts/actions.js
@@ -36,12 +36,27 @@ export const getSinglePrompt = (id) => async (dispatch, getState) => {
   }
 };
 
+export const postPrompt = (userId, description, name) => async (
+  dispatch,
+  getState
+) => {
+  try {
+    const response = await Axios.post(`${apiUrl}/prompts/new`, {
+      userId,
+      description,
+      name,
+    });
+    console.log("response is:", response);
+  } catch (e) {
+    console.log(e);
+  }
+};
+
 export const postStory = (description, name, promptId, userId) => async (
   dispatch,
   getState
 ) => {
   try {
-    // console.log("Story", { description, name, promptId, userId });
     const response = await Axios.post(`${apiUrl}/stories/new`, {
       description,
       name,


### PR DESCRIPTION
## What this pull request does:
- Creates new page at /prompt/new
  - with basic controlled form for writing a new prompt
  - when submitted data is send to backend to create new prompt entry in the database

### Future must have
- integration with log-in
  - When user logged in display "write new prompt" in navbar
  - When submitting newly written prompt, take logged-in user's id 
