### PR TITLE
post story action now has auth header /w token

### DIFF
--- a/src/store/prompts/actions.js
+++ b/src/store/prompts/actions.js
@@ -1,6 +1,7 @@
 import Axios from "axios";
 import { apiUrl } from "../../config/constants";
 import { selectPrompts } from "./selectors";
+import { selectToken } from "../user/selectors";
 
 export const storePrompts = (prompts) => ({
   type: "STORE_PROMPTS",
@@ -56,13 +57,22 @@ export const postStory = (description, name, promptId, userId) => async (
   dispatch,
   getState
 ) => {
+  const token = selectToken(getState());
+  if (token === null) return;
+
   try {
-    const response = await Axios.post(`${apiUrl}/stories/new`, {
-      description,
-      name,
-      promptId,
-      userId,
-    });
+    const response = await Axios.post(
+      `${apiUrl}/stories/new`,
+      {
+        description,
+        name,
+        promptId,
+        userId,
+      },
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      }
+    );
     console.log("response is:", response);
   } catch (e) {
     console.log(e);


### PR DESCRIPTION
## What this pull request does:
- previous write-story-integration branch did not have authorization functionality when posting to the back end, fixed that