### PR TITLE
Feat delete story

### DIFF
--- a/src/components/StoryCard/index.js
+++ b/src/components/StoryCard/index.js
@@ -1,15 +1,25 @@
 import React from "react";
-import { useSelector } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
 import { selectUser } from "../../store/user/selectors";
+import { deleteStory } from "../../store/stories/actions";
 
 export default function StoryCard(props) {
+  const dispatch = useDispatch();
   const user = useSelector(selectUser);
+  //console.log("props:", props);
+  function deletePressed() {
+    dispatch(deleteStory(props.id));
+  }
 
   return (
     <div>
       <h4>Title: {props.name}</h4>
       <p>{props.description}</p>
-      {props.id === user.id ? <button> Delete </button> : ""}
+      {props.userId === user.id ? (
+        <button onClick={deletePressed}> Delete </button>
+      ) : (
+        ""
+      )}
     </div>
   );
 }

--- a/src/components/StoryCard/index.js
+++ b/src/components/StoryCard/index.js
@@ -1,10 +1,15 @@
 import React from "react";
+import { useSelector } from "react-redux";
+import { selectUser } from "../../store/user/selectors";
 
 export default function StoryCard(props) {
+  const user = useSelector(selectUser);
+
   return (
     <div>
       <h4>Title: {props.name}</h4>
       <p>{props.description}</p>
+      {props.id === user.id ? <button> Delete </button> : ""}
     </div>
   );
 }

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -1,28 +1,36 @@
 import React, { useEffect } from "react";
 import { useSelector, useDispatch } from "react-redux";
-import { selectUser } from "../store/user/selectors";
+import { selectUser, selectToken } from "../store/user/selectors";
 import { Container, Col, Row } from "react-bootstrap";
 import { selectPrompts } from "../store/prompts/selectors";
 import { fetchStories, getStoriesbyUserId } from "../store/stories/actions";
 import { selectStories } from "../store/stories/selectors";
 import StoryCard from "../components/StoryCard";
 import PromptCard from "../components/PromptCard";
+import { useHistory } from "react-router-dom";
 
 export default function Profile() {
   const dispatch = useDispatch();
+  const history = useHistory();
+
   const user = useSelector(selectUser);
   const prompts = useSelector(selectPrompts).filter(
     (prompt) => prompt.userId === user.id
   );
   const stories = useSelector(selectStories);
+  const token = useSelector(selectToken);
 
   function test() {
     dispatch(getStoriesbyUserId(user.id));
   }
 
   useEffect(() => {
-    //dispatch(fetchStories());
-    dispatch(getStoriesbyUserId(user.id));
+    if (token === null) {
+      history.push("/login");
+    } else {
+      //dispatch(fetchStories());
+      dispatch(getStoriesbyUserId(user.id));
+    }
   }, [dispatch, user.id]);
 
   const oldRender = () => {

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -1,10 +1,12 @@
 import React, { useEffect } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { selectUser } from "../store/user/selectors";
-import { Container } from "react-bootstrap";
+import { Container, Col, Row } from "react-bootstrap";
 import { selectPrompts } from "../store/prompts/selectors";
-import { fetchStories } from "../store/stories/actions";
+import { fetchStories, getStoriesbyUserId } from "../store/stories/actions";
 import { selectStories } from "../store/stories/selectors";
+import StoryCard from "../components/StoryCard";
+import PromptCard from "../components/PromptCard";
 
 export default function Profile() {
   const dispatch = useDispatch();
@@ -13,44 +15,91 @@ export default function Profile() {
     (prompt) => prompt.userId === user.id
   );
   const stories = useSelector(selectStories);
+  console.log("stories", stories);
+  const alternatePrompts = useSelector(selectPrompts);
+
+  function test() {
+    dispatch(getStoriesbyUserId(user.id));
+  }
 
   useEffect(() => {
-    dispatch(fetchStories());
+    //dispatch(fetchStories());
+    dispatch(getStoriesbyUserId(user.id));
   }, [dispatch]);
 
-  console.log(user);
-  console.log(prompts);
-  return (
-    <Container>
-      <div style={{ display: "flex" }}>
-        <div style={{ width: "5em", margin: "0em 1em" }}>
-          <img
-            style={{ width: "100%" }}
-            src="https://picsum.photos/200"
-            alt="profile"
-          />
+  // console.log(user);
+  //console.log("prompts:", alternatePrompts);
+  const oldRender = () => {
+    return (
+      <Container>
+        <div style={{ display: "flex" }}>
+          <button onClick={test}>test</button>
+          <div style={{ width: "5em", margin: "0em 1em" }}>
+            <img
+              style={{ width: "100%" }}
+              src="https://picsum.photos/200"
+              alt="profile"
+            />
+          </div>
+          <h4>{user.name}</h4>
         </div>
-        <h4>{user.name}</h4>
-      </div>
-      <div
-        style={{
-          display: "flex",
-          justifyContent: "space-evenly",
-        }}
-      >
-        <div style={{ margin: "1em" }}>
-          <h4>My stories</h4>
-          {stories.map((story) => (
-            <p>{story.description}</p>
-          ))}
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-evenly",
+          }}
+        >
+          <div style={{ margin: "1em" }}>
+            <h4>My stories</h4>
+            {stories.map((story) => (
+              <StoryCard key={story.id} {...story} />
+            ))}
+          </div>
+          <div style={{ margin: "1em" }}>
+            <h4>My prompts</h4>
+            {prompts.map((prompt) => (
+              <PromptCard key={prompt.id} {...prompt} />
+            ))}
+          </div>
         </div>
-        <div style={{ margin: "1em" }}>
-          <h4>My prompts</h4>
-          {prompts.map((prompt) => (
-            <p>{prompt.description}</p>
-          ))}
-        </div>
-      </div>
-    </Container>
-  );
+      </Container>
+    );
+  };
+
+  const profileToRender = () => {
+    return (
+      <Container>
+        <Row>
+          {/* <Col>
+            <button onClick={test}>test</button>
+          </Col> */}
+          <Col>
+            <img
+              src="https://picsum.photos/200"
+              alt="profile"
+              style={{ float: "right" }}
+            ></img>
+          </Col>
+          <Col>
+            <h1>{user.name}</h1>
+          </Col>
+        </Row>
+        <Row>
+          <Col>
+            <h4>My prompts</h4>
+            {prompts.map((prompt) => (
+              <PromptCard key={prompt.id} {...prompt} />
+            ))}
+          </Col>
+          <Col>
+            <h4>My stories</h4>
+            {stories.map((story) => (
+              <StoryCard key={story.id} {...story} />
+            ))}
+          </Col>
+        </Row>
+      </Container>
+    );
+  };
+  return <div>{profileToRender()}</div>;
 }

--- a/src/pages/Profile.js
+++ b/src/pages/Profile.js
@@ -15,8 +15,6 @@ export default function Profile() {
     (prompt) => prompt.userId === user.id
   );
   const stories = useSelector(selectStories);
-  console.log("stories", stories);
-  const alternatePrompts = useSelector(selectPrompts);
 
   function test() {
     dispatch(getStoriesbyUserId(user.id));
@@ -25,10 +23,8 @@ export default function Profile() {
   useEffect(() => {
     //dispatch(fetchStories());
     dispatch(getStoriesbyUserId(user.id));
-  }, [dispatch]);
+  }, [dispatch, user.id]);
 
-  // console.log(user);
-  //console.log("prompts:", alternatePrompts);
   const oldRender = () => {
     return (
       <Container>
@@ -70,9 +66,6 @@ export default function Profile() {
     return (
       <Container>
         <Row>
-          {/* <Col>
-            <button onClick={test}>test</button>
-          </Col> */}
           <Col>
             <img
               src="https://picsum.photos/200"

--- a/src/store/stories/actions.js
+++ b/src/store/stories/actions.js
@@ -1,10 +1,10 @@
 import axios from "axios";
 import { apiUrl } from "../../config/constants";
 import { selectStories } from "./selectors";
-import { selectToken } from "../user/selectors";
+import { selectToken, selectUser } from "../user/selectors";
 import Axios from "axios";
 import { getPrompts, getSinglePrompt } from "../prompts/actions";
-import { selectSinglePrompt } from "../prompts/selectors";
+import { selectSinglePrompt, selectPrompts } from "../prompts/selectors";
 
 export const STORE_STORIES = "STORE_STORIES";
 
@@ -28,11 +28,33 @@ export const fetchStories = () => async (dispatch, getState) => {
     console.log(error);
   }
 };
+export const getStoriesbyUserId = (userId) => async (dispatch, getState) => {
+  const state = selectPrompts(getState());
+  console.log("state:", state);
+  // if (state.length) {
+  //   const stories = state.map((prompt) => {
+  //     // return  {...prompt.stories} ;
+  //     prompt.stories.forEach((story) => {
+  //       return { ...story };
+  //     });
+  //   });
+  //   //console.log("State has length");
+  //   console.log("stories:", stories);
+  // }
+  try {
+    const response = await Axios.get(`${apiUrl}/stories/user/${userId}`);
+    console.log(" getstoriesbyuserid response is:", response.data);
+    dispatch(fetchSucces(response.data));
+  } catch (e) {
+    console.log(e);
+  }
+};
 
 export const deleteStory = (id) => async (dispatch, getState) => {
   //console.log("deleting story with id:", id);
   const token = selectToken(getState());
   const prompt = selectSinglePrompt(getState());
+  const user = selectUser(getState());
 
   if (token === null) return;
   try {
@@ -40,6 +62,7 @@ export const deleteStory = (id) => async (dispatch, getState) => {
     console.log("response", response);
     await dispatch(getPrompts());
     dispatch(getSinglePrompt(prompt.id));
+    dispatch(getStoriesbyUserId(user.id));
   } catch (e) {
     console.log(e);
   }

--- a/src/store/stories/actions.js
+++ b/src/store/stories/actions.js
@@ -3,6 +3,8 @@ import { apiUrl } from "../../config/constants";
 import { selectStories } from "./selectors";
 import { selectToken } from "../user/selectors";
 import Axios from "axios";
+import { getPrompts, getSinglePrompt } from "../prompts/actions";
+import { selectSinglePrompt } from "../prompts/selectors";
 
 export const STORE_STORIES = "STORE_STORIES";
 
@@ -30,9 +32,14 @@ export const fetchStories = () => async (dispatch, getState) => {
 export const deleteStory = (id) => async (dispatch, getState) => {
   //console.log("deleting story with id:", id);
   const token = selectToken(getState());
+  const prompt = selectSinglePrompt(getState());
+
   if (token === null) return;
   try {
     const response = await Axios.delete(`${apiUrl}/stories/delete/${id}`);
+    console.log("response", response);
+    await dispatch(getPrompts());
+    dispatch(getSinglePrompt(prompt.id));
   } catch (e) {
     console.log(e);
   }

--- a/src/store/stories/actions.js
+++ b/src/store/stories/actions.js
@@ -66,7 +66,9 @@ export const deleteStory = (id) => async (dispatch, getState) => {
 
   if (token === null) return;
   try {
-    const response = await Axios.delete(`${apiUrl}/stories/delete/${id}`);
+    const response = await Axios.delete(`${apiUrl}/stories/delete/${id}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
     console.log("response", response);
     await dispatch(getPrompts());
     dispatch(getSinglePrompt(prompt.id));

--- a/src/store/stories/actions.js
+++ b/src/store/stories/actions.js
@@ -1,6 +1,8 @@
 import axios from "axios";
 import { apiUrl } from "../../config/constants";
 import { selectStories } from "./selectors";
+import { selectToken } from "../user/selectors";
+import Axios from "axios";
 
 export const STORE_STORIES = "STORE_STORIES";
 
@@ -22,5 +24,16 @@ export const fetchStories = () => async (dispatch, getState) => {
     }
   } catch (error) {
     console.log(error);
+  }
+};
+
+export const deleteStory = (id) => async (dispatch, getState) => {
+  //console.log("deleting story with id:", id);
+  const token = selectToken(getState());
+  if (token === null) return;
+  try {
+    const response = await Axios.delete(`${apiUrl}/stories/delete/${id}`);
+  } catch (e) {
+    console.log(e);
   }
 };

--- a/src/store/stories/reducer.js
+++ b/src/store/stories/reducer.js
@@ -5,7 +5,7 @@ const initialState = [];
 export default (state = initialState, { type, payload }) => {
   switch (type) {
     case STORE_STORIES:
-      return [...state, ...payload];
+      return [...payload];
 
     default:
       return state;


### PR DESCRIPTION
## What this pull request does:
- Refactor of Profile page
  - if not logged in, redirects to login page
  - Gets only the stories that belong to the logged in user (prev. all stories)
  - Provides new fetching action, to database
    - Check if data exist in local state, gets it from there
    - if it does not it fetches it from the database (for future purposes)
  - Refactor layout to use react-bootstrap (Row & Col components)
    - Previous layout shifted depending on length of stories/prompts, now stays static
    - Old render still in code for consideration
  - Now displays stories & prompts using card components
  - Fixed stories reducer to remove duplication of stories
- When user is logged-in all stories belonging can be deleted by him
  - all stories belonging to user now display delete button
    - In prompt page & on Profile page
  - When story gets deleted, page updates automatically
    - in prompt page & on Profile page
  - Deleting story has authorization header from loggedin users token